### PR TITLE
[JENKINS-7257] More verbose site name

### DIFF
--- a/src/main/java/be/certipost/hudson/plugin/SCPRepositoryPublisher.java
+++ b/src/main/java/be/certipost/hudson/plugin/SCPRepositoryPublisher.java
@@ -317,7 +317,7 @@ public final class SCPRepositoryPublisher extends Notifier {
 			if (hostname == null) {// hosts is not entered yet
 				return FormValidation.ok();
 			}
-			SCPSite site = new SCPSite(hostname, request.getParameter("port"),
+			SCPSite site = new SCPSite("", hostname, request.getParameter("port"),
 					request.getParameter("user"), request.getParameter("pass"),
 					request.getParameter("keyfile"));
 			try {

--- a/src/main/java/be/certipost/hudson/plugin/SCPSite.java
+++ b/src/main/java/be/certipost/hudson/plugin/SCPSite.java
@@ -32,6 +32,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * 
  */
 public class SCPSite {
+	String displayname;
 	String hostname;
 	int port;
 	String username;
@@ -46,8 +47,9 @@ public class SCPSite {
 
 	}
 
-	public SCPSite(String hostname, int port, String username, String password,
+	public SCPSite(String displayname, String hostname, int port, String username, String password,
 			String rootRepositoryPath) {
+		this.displayname = displayname;
 		this.hostname = hostname;
 		this.port = port;
 		this.username = username;
@@ -55,8 +57,9 @@ public class SCPSite {
 		this.rootRepositoryPath = rootRepositoryPath.trim();
 	}
 
-	public SCPSite(String hostname, String port, String username,
+	public SCPSite(String displayname, String hostname, String port, String username,
 			String password) {
+		this.displayname = displayname;
 		this.hostname = hostname;
 		try {
 			this.port = Integer.parseInt(port);
@@ -67,9 +70,9 @@ public class SCPSite {
 		this.password = password;
 	}
 
-	public SCPSite(String hostname, String port, String username,
+	public SCPSite(String displayname, String hostname, String port, String username,
 			String passphrase, String keyfile) {
-		this(hostname, port, username, passphrase);
+		this(displayname, hostname, port, username, passphrase);
 
 		this.keyfile = keyfile;
 	}
@@ -82,6 +85,14 @@ public class SCPSite {
 		this.keyfile = keyfile;
 	}
 
+	public String getDisplayname() {
+		return displayname;
+	}
+
+	public void setDisplayname(String displayname) {
+		this.displayname = displayname;
+	}
+	
 	public String getHostname() {
 		return hostname;
 	}
@@ -131,7 +142,11 @@ public class SCPSite {
 	}
 
 	public String getName() {
-		return hostname;
+		if (StringUtils.isEmpty(displayname)) {
+			return username + "@" + hostname + ":" + rootRepositoryPath;
+		} else {
+			return displayname;
+		}
 	}
 
 	public Session createSession(PrintStream logger) throws JSchException {

--- a/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/global.jelly
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/global.jelly
@@ -5,6 +5,9 @@
       description="${%SCP sites that projects will want to connect}">
       <f:repeatable var="site" items="${descriptor.sites}">
         <table width="100%">
+          <f:entry title="${%Displayname}" help="/plugin/scp/help-displayname.html">
+            <f:textbox name="scp.displayname" value="${site.displayname}"/>
+          </f:entry>
           <f:entry title="${%Hostname}" help="/plugin/scp/help-hostname.html">
             <f:textbox name="scp.hostname" value="${site.hostname}"/>
           </f:entry>

--- a/src/main/webapp/help-displayname.html
+++ b/src/main/webapp/help-displayname.html
@@ -1,0 +1,1 @@
+<div>SCP Display Name</div>


### PR DESCRIPTION
Add a new field "displayname" that can be used to give a site any name the user wants. If the displayname field is not used, then the displayname will default to username@hostname:rootRepositoryPath
