### PR TITLE
Fix help messages

### DIFF
--- a/src/main/resources/be/certipost/hudson/plugin/Entry/config.jelly
+++ b/src/main/resources/be/certipost/hudson/plugin/Entry/config.jelly
@@ -7,17 +7,17 @@
   </f:entry>
 
   <f:entry title="${%Copy Console Log}" field="copyConsoleLog"
-    description="${%Check if we should write the Console Log to the Remote Desintation.}">
+    description="${%Check if we should write the Console Log to the Remote Destination.}">
     <f:checkbox checked="${e.copyConsoleLog}" />
   </f:entry>
 
   <f:entry title="${%Keep Hierarchy}" field="keepHierarchy"
-    description="${%Keep directory hierarchy relative to the workspace when copying to the remote destination.}">
+    description="${%Keep directory hierarchy relative to the workspace when copying to the Remote Destination.}">
     <f:checkbox checked="${e.keepHierarchy}" />
   </f:entry>
 
   <f:entry title="${%Copy after failure}" field="copyAfterFailure"
-    description="${%Check if we should copy the source file to the remote destination after a build failure.%}">
+    description="${%Check if we should copy the source file to the Remote Destination after a build failure.%}">
     <f:checkbox checked="${e.copyAfterFailure}" />
   </f:entry>
 

--- a/src/main/resources/be/certipost/hudson/plugin/Entry/help-copyAfterFailure.html
+++ b/src/main/resources/be/certipost/hudson/plugin/Entry/help-copyAfterFailure.html
@@ -1,0 +1,4 @@
+<div>
+  Copy the source file to the Remote Destination even when the build
+  has failed.
+</div>

--- a/src/main/resources/be/certipost/hudson/plugin/Entry/help-copyConsoleLog.html
+++ b/src/main/resources/be/certipost/hudson/plugin/Entry/help-copyConsoleLog.html
@@ -1,0 +1,4 @@
+<div>
+  Copy the Console Log for this build to the Remote Destination. The source
+  file will be ignored if this option is checked.
+</div>

--- a/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/config.jelly
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/config.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%SCP site}" field="siteName"
-            description="Select configured SCP host.Check global hudson config for defining connection properties for this hosts">
+            description="Select configured SCP host. Check global Jenkins config for defining connection properties for this host.">
       <f:select />
     </f:entry>
 

--- a/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyAfterFailure.html
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyAfterFailure.html
@@ -1,4 +1,0 @@
-<div>
-  Copy the source file to the remote destination even when the build
-  has failed.
-</div>

--- a/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyConsoleLog.html
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyConsoleLog.html
@@ -1,4 +1,0 @@
-<div>
-  Copy the console log for this build to the remote destination. The source
-  file will be ignored if this option is checked.
-</div>

--- a/src/main/resources/be/certipost/hudson/plugin/SCPSite/config.jelly
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPSite/config.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Displayname}" field="displayname">
+  <f:entry title="${%Display Name}" field="displayname">
     <f:textbox />
   </f:entry>
   <f:entry title="${%Hostname}" field="hostname">
@@ -20,7 +20,7 @@
   <f:entry title="${%Keyfile}" field="keyfile">
     <f:textbox />
   </f:entry>
-  
+
   <f:entry>
     <f:validateButton title="${%Test Connection}" method="loginCheck" with="hostname,port,username,password,keyfile" />
   </f:entry>

--- a/src/main/webapp/help-hostselect.html
+++ b/src/main/webapp/help-hostselect.html
@@ -1,1 +1,4 @@
-<div>Select configured SCP host.Check global hudson config for defining connection properties for this hosts</div>
+<div>
+  Select configured SCP host. Check global Jenkins config for defining
+  connection properties for this hosts
+</div>


### PR DESCRIPTION
- Move help messages to the right folder
- Make capitalization in messages more consistent
- Fix various typos
- Now refer to Jenkins in help messages
