### PR TITLE
Update Jenkins to a reasonable version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.430</version>
+    <version>1.554</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Plan to integrate this plugin with `credentials-plugin` which needs at least `1.520 `.

`1.430` is just too old.

@reviewbybees