### PR TITLE
Support copying both console and source in same entry

### DIFF
--- a/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyConsoleLog.html
+++ b/src/main/resources/be/certipost/hudson/plugin/SCPRepositoryPublisher/help-copyConsoleLog.html
@@ -1,4 +1,3 @@
 <div>
-  Copy the console log for this build to the remote destination. The source
-  file will be ignored if this option is checked.
+  Copy the console log for this build to the remote destination.
 </div>


### PR DESCRIPTION
Allow users to specify both a source file pattern and to request the
console to be copied to the same location on the target site.
