### PR TITLE
Added JSch logging implementation to provide more details on JSch logic

### DIFF
--- a/src/main/java/be/certipost/hudson/plugin/JSchJDKLogger.java
+++ b/src/main/java/be/certipost/hudson/plugin/JSchJDKLogger.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 Anthony Wat
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package be.certipost.hudson.plugin;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * An implementation of the JSch logger which writes log to a JDK logger.
+ * 
+ * @author Anthony Wat
+ *
+ */
+public class JSchJDKLogger implements com.jcraft.jsch.Logger {
+
+	/**
+	 * The JDK logger to log to.
+	 */
+	private Logger logger;
+
+	/**
+	 * Creates a new <code>JSchJDKLogger</code> instance.
+	 * 
+	 * @param logger
+	 *            The JDK logger to log to.
+	 */
+	public JSchJDKLogger(Logger logger) {
+		this.logger = logger;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see com.jcraft.jsch.Logger#isEnabled(int)
+	 */
+	public boolean isEnabled(int level) {
+		Level jdkLogLevel = null;
+		if (logger == null || (jdkLogLevel = toJDKLogLevel(level)) == Level.OFF) {
+			return false;
+		}
+		// Return true if the JDK logger level emcompasses the given JSch log
+		// level
+		return logger.getLevel().intValue() <= jdkLogLevel.intValue();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see com.jcraft.jsch.Logger#log(int, java.lang.String)
+	 */
+	public void log(int level, String message) {
+		if (logger != null) {
+			logger.log(toJDKLogLevel(level), message);
+		}
+	}
+
+	/**
+	 * Returns the equivalent JDK log level given the JSch log level.
+	 * 
+	 * @param level
+	 *            The log level.
+	 * @return The equivalent JDK logger log level.
+	 */
+	private Level toJDKLogLevel(int level) {
+		if (level == com.jcraft.jsch.Logger.DEBUG) {
+			return Level.ALL;
+		} else if (level == com.jcraft.jsch.Logger.INFO) {
+			return Level.INFO;
+		} else if (level == com.jcraft.jsch.Logger.WARN) {
+			return Level.WARNING;
+		} else if (level == com.jcraft.jsch.Logger.ERROR || level == com.jcraft.jsch.Logger.FATAL) {
+			return Level.SEVERE;
+		}
+		return Level.OFF;
+	}
+
+}

--- a/src/main/java/be/certipost/hudson/plugin/SCPSite.java
+++ b/src/main/java/be/certipost/hudson/plugin/SCPSite.java
@@ -1,5 +1,26 @@
 package be.certipost.hudson.plugin;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SftpATTRS;
+import com.jcraft.jsch.SftpException;
+import com.jcraft.jsch.UserInfo;
+
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
@@ -12,28 +33,7 @@ import hudson.model.Hudson.MasterComputer;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
-
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.SftpATTRS;
-import com.jcraft.jsch.SftpException;
-import com.jcraft.jsch.UserInfo;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  *
@@ -145,6 +145,10 @@ public class SCPSite extends AbstractDescribableImpl<SCPSite> {
 
     public Session createSession(PrintStream logger) throws JSchException {
         JSch jsch = new JSch();
+        
+		// Sets a custom JSch logger to write additional info to the JDK logger
+		// of this class
+        JSch.setLogger(new JSchJDKLogger(LOGGER));
 
         Session session = jsch.getSession(username, hostname, port);
         if (this.keyfile != null && this.keyfile.length() > 0) {
@@ -158,6 +162,7 @@ public class SCPSite extends AbstractDescribableImpl<SCPSite> {
 
         java.util.Properties config = new java.util.Properties();
         config.put("StrictHostKeyChecking", "no");
+
         session.setConfig(config);
         session.connect();
 


### PR DESCRIPTION
Earlier I ran into an issue where SCP connection test keeps failing with a generic "Auth fail" error. I learned that JSch requires implementation of its own logger, so I added one that writes to the JDK logger of the SCP plugin. It provided additional info which were useful in reviewing the auth stack details, which indicated that password auth wasn't working. I'd like to contribute the little bit of code for the benefits of others.

Please review and let me know if there's any feedback. Otherwise I appreciate your help in merging the pull request.

Thanks very much for your help.
